### PR TITLE
i39 - Increase Data-Frame Width

### DIFF
--- a/client-code/Stylesheet.html
+++ b/client-code/Stylesheet.html
@@ -75,7 +75,7 @@
 
   .data-frame {
     padding: 2em;
-    width: 75%;
+    width: 90%;
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
Increase the data-frame CSS class width from 75% to 90% in order to satisfy #39 and decrease the margin size left and right