### PR TITLE
i127 - Change README Commit Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Northeastern Electric Racing Project Management Dashboard
 - Creating commits:
 	- Commits are essentially the Cmd+S of github. As such, its useful to save your work often
 	- Type `git commit -a -m [message]` to commit
-	- Style your message in the format: `i[issue number] - [description of changes made]` (e.g. `i18 - fixed typo in variable name`)
+	- Style your message in the format: `#[issue number] - [description of changes made]` (e.g. `#18 - fixed typo in variable name`)
 
 - To run and check code in the Google runtime environment:
 	- Make sure you have clasp installed and working


### PR DESCRIPTION
Changed README commit syntax to use '#' instead of 'I'.